### PR TITLE
Compile extension as C++ and allow Cython 3.2.x

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest hypothesis mypy Cython==3.1.6
+          pip install pytest hypothesis mypy Cython
 
       # The cythonized files allow installation from the sdist without cython
       - name: Generate cython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.11",
-    "Cython>=3.1.6,<3.2.0"
+    "Cython>=3.1.6,<3.3.0"
 ]
 build-backend = "scikit_build_core.build"
 

--- a/src/Levenshtein/CMakeLists.txt
+++ b/src/Levenshtein/CMakeLists.txt
@@ -9,7 +9,7 @@ function(create_cython_target _name)
       MAIN_DEPENDENCY "${CMAKE_CURRENT_LIST_DIR}/${_name}.pyx"
       VERBATIM
       COMMAND
-        Python::Interpreter -m cython "${CMAKE_CURRENT_LIST_DIR}/${_name}.pyx"
+        Python::Interpreter -m cython --cplus "${CMAKE_CURRENT_LIST_DIR}/${_name}.pyx"
         --output-file "${CMAKE_CURRENT_BINARY_DIR}/${_name}.cxx")
 
     set(${_name}

--- a/tools/sdist.patch
+++ b/tools/sdist.patch
@@ -6,7 +6,7 @@ index 0a8c033..cf967b9 100644
  [build-system]
  requires = [
 -    "scikit-build-core>=0.11",
--    "Cython>=3.1.6,<3.2.0"
+-    "Cython>=3.1.6,<3.3.0"
 +    "scikit-build-core>=0.11"
  ]
  build-backend = "scikit_build_core.build"


### PR DESCRIPTION
Fixes the build with Cython 3.2.4 by compiling the extension explicitly as cpp.

```
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
*** scikit-build-core 0.11.6 using CMake 4.1.2 (wheel)
*** Configuring CMake...
loading initial cache file /build/tmp5ovl2h1w/build/CMakeInit.txt
-- The C compiler identification is GNU 15.2.0
-- The CXX compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/qg2lsffxcvwbcfnidqkf9qwxfrgxvn82-gcc-wrapper-15.2.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/qg2lsffxcvwbcfnidqkf9qwxfrgxvn82-gcc-wrapper-15.2.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /nix/store/0d41v0k205lz6w53dc5fyrn1ldl2lk41-python3-3.13.11/bin/python3.13 (found version "3.13.11") found components: Interpreter Development.Module
-- Using system supplied version of rapidfuzz-cpp
-- Configuring done (1.6s)
-- Generating done (0.0s)
-- Build files have been written to: /build/tmp5ovl2h1w/build
*** Building project with Ninja...
[1/4] Generating levenshtein_cpp.cxx
FAILED: [code=1] src/Levenshtein/levenshtein_cpp.cxx /build/tmp5ovl2h1w/build/src/Levenshtein/levenshtein_cpp.cxx 
cd /build/tmp5ovl2h1w/build/src/Levenshtein && /nix/store/0d41v0k205lz6w53dc5fyrn1ldl2lk41-python3-3.13.11/bin/python3.13 -m cython /build/source/src/Levenshtein/levenshtein_cpp.pyx --output-file /build/tmp5ovl2h1w/build/src/Levenshtein/levenshtein_cpp.cxx
warning: /build/source/src/Levenshtein/levenshtein_cpp.pyx:1:0: Filename implies a c++ file but Cython is not in c++ mode.
warning: /nix/store/8a0absir671msvwcsy8msbh1v6k8awri-python3.13-cython-3.2.4/lib/python3.13/site-packages/Cython/Includes/libcpp/vector.pxd:2:4: Using 'cppclass' while Cython is not in c++ mode
warning: /nix/store/8a0absir671msvwcsy8msbh1v6k8awri-python3.13-cython-3.2.4/lib/python3.13/site-packages/Cython/Includes/libcpp/utility.pxd:2:4: Using 'cppclass' while Cython is not in c++ mode

Error compiling Cython file:
------------------------------------------------------------
...
cdef extern from *:
    int PyUnicode_4BYTE_KIND
    object PyUnicode_FromKindAndData(int kind, const void *buffer, Py_ssize_t size)

cdef extern from "_levenshtein.hpp":
    cdef vector[uint32_t] lev_greedy_median(const vector[RF_String]& strings, const vector[double]& weights) except +
                                           ^
------------------------------------------------------------
/build/source/src/Levenshtein/levenshtein_cpp.pyx:13:43: Operation only allowed in c++

Error compiling Cython file:
------------------------------------------------------------
...
    int PyUnicode_4BYTE_KIND
    object PyUnicode_FromKindAndData(int kind, const void *buffer, Py_ssize_t size)

cdef extern from "_levenshtein.hpp":
    cdef vector[uint32_t] lev_greedy_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_median_improve(const RF_String& string, const vector[RF_String]& strings, const vector[double]& weights) except +
                                            ^
------------------------------------------------------------
/build/source/src/Levenshtein/levenshtein_cpp.pyx:14:44: Operation only allowed in c++

Error compiling Cython file:
------------------------------------------------------------
...
    object PyUnicode_FromKindAndData(int kind, const void *buffer, Py_ssize_t size)

cdef extern from "_levenshtein.hpp":
    cdef vector[uint32_t] lev_greedy_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_median_improve(const RF_String& string, const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_quick_median(const vector[RF_String]& strings, const vector[double]& weights) except +
                                          ^
------------------------------------------------------------
/build/source/src/Levenshtein/levenshtein_cpp.pyx:15:42: Operation only allowed in c++

Error compiling Cython file:
------------------------------------------------------------
...

cdef extern from "_levenshtein.hpp":
    cdef vector[uint32_t] lev_greedy_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_median_improve(const RF_String& string, const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_quick_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_set_median(const vector[RF_String]& strings, const vector[double]& weights) except +
                                        ^
------------------------------------------------------------
/build/source/src/Levenshtein/levenshtein_cpp.pyx:16:40: Operation only allowed in c++

Error compiling Cython file:
------------------------------------------------------------
...
    cdef vector[uint32_t] lev_greedy_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_median_improve(const RF_String& string, const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_quick_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_set_median(const vector[RF_String]& strings, const vector[double]& weights) except +

    cdef double lev_set_distance(const vector[RF_String]& strings1, const vector[RF_String]& strings2) except +
                                ^
------------------------------------------------------------
/build/source/src/Levenshtein/levenshtein_cpp.pyx:18:32: Operation only allowed in c++

Error compiling Cython file:
------------------------------------------------------------
...
    cdef vector[uint32_t] lev_median_improve(const RF_String& string, const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_quick_median(const vector[RF_String]& strings, const vector[double]& weights) except +
    cdef vector[uint32_t] lev_set_median(const vector[RF_String]& strings, const vector[double]& weights) except +

    cdef double lev_set_distance(const vector[RF_String]& strings1, const vector[RF_String]& strings2) except +
    cdef double lev_edit_seq_distance(const vector[RF_String]& strings1, const vector[RF_String]& strings2) except +
                                     ^
------------------------------------------------------------
/build/source/src/Levenshtein/levenshtein_cpp.pyx:19:37: Operation only allowed in c++
ninja: build stopped: subcommand failed.

*** CMake build failed

ERROR Backend subprocess exited when trying to invoke build_wheel
```