### PR TITLE
`StringMatcher` type annotations

### DIFF
--- a/src/Levenshtein/StringMatcher.py
+++ b/src/Levenshtein/StringMatcher.py
@@ -1,18 +1,34 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Literal
 from warnings import warn
 
 from Levenshtein import distance, editops, matching_blocks, opcodes, ratio
+
+if TYPE_CHECKING:
+    from Levenshtein import _EditopsList, _MatchingBlocks, _OpcodesList
 
 
 class StringMatcher:
     """A SequenceMatcher-like class built on the top of Levenshtein"""
 
-    def _reset_cache(self):
+    _ratio: float | None
+    _distance: int | None
+    _opcodes: _OpcodesList | None
+    _editops: _EditopsList | None
+    _matching_blocks: _MatchingBlocks | None
+
+    def _reset_cache(self) -> None:
         self._ratio = self._distance = None
         self._opcodes = self._editops = self._matching_blocks = None
 
-    def __init__(self, isjunk=None, seq1="", seq2="", autojunk=False):
+    def __init__(
+        self,
+        isjunk: Literal[False] | None = None,
+        seq1: str = "",
+        seq2: str = "",
+        autojunk: Literal[False] = False,
+    ) -> None:
         if isjunk:
             warn("isjunk NOT implemented, it will be ignored", stacklevel=1)
         if autojunk:
@@ -20,19 +36,19 @@ class StringMatcher:
         self._str1, self._str2 = seq1, seq2
         self._reset_cache()
 
-    def set_seqs(self, seq1, seq2):
+    def set_seqs(self, seq1: str, seq2: str) -> None:
         self._str1, self._str2 = seq1, seq2
         self._reset_cache()
 
-    def set_seq1(self, seq1):
+    def set_seq1(self, seq1: str) -> None:
         self._str1 = seq1
         self._reset_cache()
 
-    def set_seq2(self, seq2):
+    def set_seq2(self, seq2: str) -> None:
         self._str2 = seq2
         self._reset_cache()
 
-    def get_opcodes(self):
+    def get_opcodes(self) -> _OpcodesList:
         if not self._opcodes:
             if self._editops:
                 self._opcodes = opcodes(self._editops, self._str1, self._str2)
@@ -40,7 +56,7 @@ class StringMatcher:
                 self._opcodes = opcodes(self._str1, self._str2)
         return self._opcodes
 
-    def get_editops(self):
+    def get_editops(self) -> _EditopsList:
         if not self._editops:
             if self._opcodes:
                 self._editops = editops(self._opcodes, self._str1, self._str2)
@@ -48,27 +64,27 @@ class StringMatcher:
                 self._editops = editops(self._str1, self._str2)
         return self._editops
 
-    def get_matching_blocks(self):
+    def get_matching_blocks(self) -> _MatchingBlocks:
         if not self._matching_blocks:
             self._matching_blocks = matching_blocks(self.get_opcodes(), self._str1, self._str2)
         return self._matching_blocks
 
-    def ratio(self):
+    def ratio(self) -> float:
         if not self._ratio:
             self._ratio = ratio(self._str1, self._str2)
         return self._ratio
 
-    def quick_ratio(self):
+    def quick_ratio(self) -> float:
         # This is usually quick enough :o)
         if not self._ratio:
             self._ratio = ratio(self._str1, self._str2)
         return self._ratio
 
-    def real_quick_ratio(self):
+    def real_quick_ratio(self) -> float:
         len1, len2 = len(self._str1), len(self._str2)
         return 2.0 * min(len1, len2) / (len1 + len2)
 
-    def distance(self):
+    def distance(self) -> int:
         if not self._distance:
             self._distance = distance(self._str1, self._str2)
         return self._distance


### PR DESCRIPTION
Hi there,

I noticed that `StringMatcher` didn't have any type coverage yet, so I figured I might as well add the type annotations :)

Before:

```console
$ pyrefly coverage check src/Levenshtein --public-only
[-- bunch of missing coverage findings --]
 ERROR type coverage 80.00% (72 of 90 typable) is below the 100.00% threshold
```

After:

```console
$ pyrefly coverage check src/Levenshtein --public-only
 INFO type coverage 100.00% (90 of 90 typable)
```

Oh and in case you care, I'm a human, and I didn't use any AI for this (it was way too much fun to this myself).