### PR TITLE
Enforce 100% type coverage in CI

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest hypothesis mypy Cython
+          pip install pytest hypothesis mypy pyrefly Cython
 
       # The cythonized files allow installation from the sdist without cython
       - name: Generate cython
@@ -40,6 +40,10 @@ jobs:
       - name: Test type stubs
         run: |
           python -m mypy.stubtest Levenshtein --ignore-missing-stub
+
+      - name: Enforce 100% type coverage
+        run: |
+          pyrefly coverage check --output-format=github src/Levenshtein
 
       - name: Test with pytest and backtrace in case of SegFault
         run: |


### PR DESCRIPTION
Now that `Levenshtein` has 100% public type coverage (#90), I figured it might be a good idea to ensure that it stays that way.

This adds a light-weight step to the CI workflow that runs `pyrefly coverage check`, which will exit 1 if the type coverage dips below 100%.

If that ever happens, e.g. because of an API change, or because Pyrefly changed something (which I don't expect will happen), then feel free to ping me :)